### PR TITLE
[POC] Router::match() returns non-i18n route

### DIFF
--- a/src/Routing/Router.php
+++ b/src/Routing/Router.php
@@ -3,6 +3,7 @@
 namespace Umpirsky\I18nRoutingBundle\Routing;
 
 use Symfony\Bundle\FrameworkBundle\Routing\Router as BaseRouter;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Exception\RouteNotFoundException;
 use Symfony\Component\Routing\RequestContext;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -57,5 +58,30 @@ class Router extends BaseRouter
         $parameters['_locale'] = array_key_exists('_locale', $parameters) ? $parameters['_locale'] : $this->context->getParameter('_locale');
 
         return parent::generate($name.$this->routeNameSuffix, $parameters, $referenceType);
+    }
+
+    public function match($pathinfo)
+    {
+        return $this->normalizeI18nMatch(parent::match($pathinfo));
+    }
+
+    public function matchRequest(Request $request)
+    {
+        return $this->normalizeI18nMatch(parent::matchRequest($request));
+    }
+
+    private function normalizeI18nMatch(array $parameters)
+    {
+        $i18nPosition = strlen($parameters['_route']) - strlen($this->routeNameSuffix);
+
+        if ($i18nPosition === strpos($parameters['_route'], $this->routeNameSuffix)) {
+            $parameters['_route'] = substr($parameters['_route'], 0, $i18nPosition);
+        }
+
+        if (!array_key_exists('_locale', $parameters)) {
+            $parameters['_locale'] = $this->defaultLocale;
+        }
+
+        return $parameters;
     }
 }

--- a/tests/Routing/RouterTest.php
+++ b/tests/Routing/RouterTest.php
@@ -4,6 +4,7 @@ namespace Umpirsky\I18nRoutingBundle\Tests\Routing;
 
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Bundle\FrameworkBundle\Routing\Router;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\RequestContext;
 use Umpirsky\I18nRoutingBundle\Routing\Router as I18nRouter;
 
@@ -105,6 +106,38 @@ class RouterTest extends KernelTestCase
             ['sr'],
             ['ru'],
             ['pl'],
+        ];
+    }
+
+    /**
+     * @dataProvider i18nRoutingWithPrefixExceptDefaultStrategyMatchProvider
+     */
+    public function testI18nRoutingWithPrefixExceptDefaultStrategyMatch($uri, $locale, $route)
+    {
+        static::bootKernel(['environment' => 'prefix_except_default']);
+
+        $router = $this->getService('router');
+        $match = $router->match($uri);
+        $requestMatch = $router->matchRequest(Request::create($uri));
+
+        $this->assertArrayHasKey('_locale', $match);
+        $this->assertArrayHasKey('_locale', $requestMatch);
+
+        $this->assertSame($locale, $match['_locale']);
+        $this->assertSame($locale, $requestMatch['_locale']);
+
+        $this->assertArrayHasKey('_route', $match);
+        $this->assertArrayHasKey('_route', $requestMatch);
+
+        $this->assertSame($route, $match['_route']);
+        $this->assertSame($route, $requestMatch['_route']);
+    }
+
+    public function i18nRoutingWithPrefixExceptDefaultStrategyMatchProvider()
+    {
+        return [
+            ['/blog', 'en', 'blog_list'],
+            ['/pl/blog', 'pl', 'blog_list'],
         ];
     }
 


### PR DESCRIPTION
This should finalize the total removal of the i18n suffixed routes from the developer.