### PR TITLE
Dependency upgrades

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ vendor
 tests/fixtures/app/cache
 tests/fixtures/app/logs
 .php_cs.cache
+var

--- a/composer.json
+++ b/composer.json
@@ -11,13 +11,13 @@
         }
     ],
     "require": {
-        "php": "^7.0",
-        "symfony/framework-bundle": "~2.7.25|~3.0|~4.0"
+        "php": "^7.0|^8.0",
+        "symfony/framework-bundle": "^4.4|^5.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^6.1",
-        "phpspec/phpspec": "~3.4|~4.2",
-        "symfony/var-dumper": "~2.7|~3.0|~4.0"
+        "phpunit/phpunit": "^8.5",
+        "phpspec/phpspec": "^7.0",
+        "symfony/var-dumper": "^4.4|^5.0"
     },
     "autoload": {
         "psr-4": { "Umpirsky\\I18nRoutingBundle\\": "src/" }

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,8 @@
     "require-dev": {
         "phpunit/phpunit": "^8.5",
         "phpspec/phpspec": "^7.0",
-        "symfony/var-dumper": "^4.4|^5.0"
+        "symfony/var-dumper": "^4.4|^5.0",
+        "symfony/phpunit-bridge": "^5.2"
     },
     "autoload": {
         "psr-4": { "Umpirsky\\I18nRoutingBundle\\": "src/" }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit colors="true" bootstrap="vendor/autoload.php">
     <php>
-       <server name="KERNEL_DIR" value="tests/fixtures/app" />
-       <server name="KERNEL_CLASS" value="AppKernel" />
+        <server name="KERNEL_DIR" value="tests/fixtures/app" />
+        <server name="KERNEL_CLASS" value="AppKernel" />
+        <server name="SYMFONY_DEPRECATIONS_HELPER" value="max[self]=0&amp;max[direct]=0"/>
     </php>
 
     <testsuites>
@@ -21,4 +22,8 @@
             </exclude>
         </whitelist>
     </filter>
+
+    <listeners>
+        <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener"/>
+    </listeners>
 </phpunit>

--- a/tests/fixtures/app/AppKernel.php
+++ b/tests/fixtures/app/AppKernel.php
@@ -15,6 +15,6 @@ class AppKernel extends Kernel
 
     public function registerContainerConfiguration(LoaderInterface $loader)
     {
-        $loader->load($this->getRootDir().'/config/config_'.$this->getEnvironment().'.yml');
+        $loader->load(__DIR__.'/config/config_'.$this->getEnvironment().'.yml');
     }
 }

--- a/tests/fixtures/app/config/config.yml
+++ b/tests/fixtures/app/config/config.yml
@@ -1,7 +1,7 @@
 framework:
     secret: SecretMyAss
     router:
-        resource: routing.yml
+        resource: '%kernel.project_dir%/tests/fixtures/app/Resources/routing.yml'
 
 umpirsky_i18n_routing:
     default_locale: en


### PR DESCRIPTION
Hey Saša, long time!

Made some dependency upgrades to allow PHP 8 & Symfony 5. I took some liberties to bump some min requirements. This makes running the test suite on all versions of PHP easier... Let me know if you'd like me to change.

I also added `symfony/phpunit-bridge` as a dev requirement to help flush out deprecations.