### PR TITLE
Enable phpspec with Symfony 6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,6 @@ jobs:
 
       - name: Run phpspec
         run: vendor/bin/phpspec run --format=pretty
-        if: matrix.symfony != '6.0.*'
 
   code-coverage:
     name: Code Coverage


### PR DESCRIPTION
Currently blocked by:

- [x] https://github.com/phpspec/prophecy/issues/527